### PR TITLE
Refine audio routing formats and conversions

### DIFF
--- a/Mixu/Audio/AudioDestination.swift
+++ b/Mixu/Audio/AudioDestination.swift
@@ -1,0 +1,130 @@
+//
+//  AudioDestination.swift
+//  Mixu
+//
+//  Created by Johan Lescure on 15/09/2025.
+//
+
+import AudioToolbox
+import Foundation
+import os.lock
+
+final class AudioDestination {
+    let uid: String
+    private let sink: OutputSink
+    private let internalFormat: StreamFormat
+    private let channelCount: Int
+    private let lock = OSAllocatedUnfairLock()
+
+    private var routes: [UUID: AudioRingBuffer] = [:]
+
+    init(uid: String, deviceID: AudioDeviceID, deviceFormat: StreamFormat, internalFormat: StreamFormat) throws {
+        self.uid = uid
+        self.internalFormat = internalFormat
+        self.channelCount = internalFormat.channelCount
+        self.sink = try OutputSink(
+            deviceID: deviceID,
+            deviceFormat: deviceFormat,
+            internalFormat: internalFormat
+        ) { [weak self] bufferList, frameCapacity in
+            guard let self else { return 0 }
+            return self.render(into: bufferList, frameCapacity: frameCapacity)
+        }
+    }
+
+    func start() {
+        sink.start()
+    }
+
+    func stop() {
+        sink.stop()
+    }
+
+    func addRoute(id: UUID, ring: AudioRingBuffer) {
+        lock.lock()
+        precondition(ring.channelCount == channelCount, "Ring buffer channel count mismatch for destination \(uid)")
+        routes[id] = ring
+        lock.unlock()
+    }
+
+    func removeRoute(id: UUID) -> Bool {
+        lock.lock()
+        routes.removeValue(forKey: id)
+        let hasRoutes = !routes.isEmpty
+        lock.unlock()
+        return hasRoutes
+    }
+
+    private func render(into bufferList: UnsafeMutableAudioBufferListPointer, frameCapacity: Int) -> Int {
+        guard frameCapacity > 0 else { return 0 }
+
+        zero(bufferList: bufferList)
+
+        lock.lock()
+        let activeRoutes = Array(routes.values)
+        lock.unlock()
+
+        guard !activeRoutes.isEmpty else { return 0 }
+
+        let channels = channelCount
+        let temp = UnsafeMutablePointer<Float>.allocate(capacity: frameCapacity * channels)
+        defer { temp.deallocate() }
+
+        var producedFrames = 0
+
+        for ring in activeRoutes {
+            let framesRead = ring.read(into: temp, frames: frameCapacity)
+            producedFrames = max(producedFrames, framesRead)
+            mix(buffer: temp, frames: framesRead, into: bufferList, channels: channels)
+        }
+
+        updateByteSizes(bufferList: bufferList, frames: producedFrames, channels: channels)
+        return producedFrames
+    }
+
+    private func zero(bufferList: UnsafeMutableAudioBufferListPointer) {
+        for buffer in bufferList {
+            if let data = buffer.mData {
+                memset(data, 0, Int(buffer.mDataByteSize))
+            }
+        }
+    }
+
+    private func mix(buffer: UnsafePointer<Float>, frames: Int, into bufferList: UnsafeMutableAudioBufferListPointer, channels: Int) {
+        guard frames > 0 else { return }
+
+        if bufferList.count == 1 {
+            guard let data = bufferList[0].mData?.assumingMemoryBound(to: Float.self) else { return }
+            for frame in 0..<frames {
+                for channel in 0..<channels {
+                    let index = frame * channels + channel
+                    data[index] = clamp(data[index] + buffer[index])
+                }
+            }
+        } else {
+            for channel in 0..<min(channels, bufferList.count) {
+                guard let data = bufferList[channel].mData?.assumingMemoryBound(to: Float.self) else { continue }
+                for frame in 0..<frames {
+                    let index = frame * channels + channel
+                    data[frame] = clamp(data[frame] + buffer[index])
+                }
+            }
+        }
+    }
+
+    private func updateByteSizes(bufferList: UnsafeMutableAudioBufferListPointer, frames: Int, channels: Int) {
+        guard frames > 0 else { return }
+
+        if bufferList.count == 1 {
+            bufferList[0].mDataByteSize = UInt32(frames * channels * MemoryLayout<Float>.size)
+        } else {
+            for channel in 0..<bufferList.count {
+                bufferList[channel].mDataByteSize = UInt32(frames * MemoryLayout<Float>.size)
+            }
+        }
+    }
+
+    private func clamp(_ value: Float) -> Float {
+        return max(-1.0, min(1.0, value))
+    }
+}

--- a/Mixu/Audio/AudioDeviceManager.swift
+++ b/Mixu/Audio/AudioDeviceManager.swift
@@ -5,6 +5,7 @@
 //  Created by Johan Lescure on 15/09/2025.
 //
 
+import AudioToolbox
 import CoreAudio
 
 // MARK: - AudioDevice Query Helpers
@@ -16,7 +17,10 @@ struct AudioDevice {
     let numInputs: Int
 }
 
-enum DeviceScope { case input, output }
+enum DeviceScope {
+    case input
+    case output
+}
 
 final class AudioDeviceManager {
     func allDevices() -> [AudioDevice] {
@@ -25,76 +29,141 @@ final class AudioDeviceManager {
             mScope: kAudioObjectPropertyScopeGlobal,
             mElement: kAudioObjectPropertyElementMain
         )
+
         var dataSize: UInt32 = 0
-        guard AudioObjectGetPropertyDataSize(AudioObjectID(kAudioObjectSystemObject), &propertyAddress, 0, nil, &dataSize) == noErr else { return [] }
+        guard AudioObjectGetPropertyDataSize(AudioObjectID(kAudioObjectSystemObject), &propertyAddress, 0, nil, &dataSize) == noErr else {
+            return []
+        }
+
         let count = Int(dataSize) / MemoryLayout<AudioDeviceID>.size
         var deviceIDs = Array(repeating: AudioDeviceID(0), count: count)
-        guard AudioObjectGetPropertyData(AudioObjectID(kAudioObjectSystemObject), &propertyAddress, 0, nil, &dataSize, &deviceIDs) == noErr else { return [] }
+
+        let status = AudioObjectGetPropertyData(AudioObjectID(kAudioObjectSystemObject), &propertyAddress, 0, nil, &dataSize, &deviceIDs)
+        guard status == noErr else { return [] }
+
         return deviceIDs.compactMap { deviceInfo(deviceID: $0) }
     }
 
     func deviceInfo(deviceID: AudioDeviceID) -> AudioDevice? {
-        func stringProp(_ selector: AudioObjectPropertySelector) -> String? {
-            var addr = AudioObjectPropertyAddress(
+        func stringProperty(_ selector: AudioObjectPropertySelector) -> String? {
+            var address = AudioObjectPropertyAddress(
                 mSelector: selector,
                 mScope: kAudioObjectPropertyScopeGlobal,
                 mElement: kAudioObjectPropertyElementMain
             )
+
             var dataSize: UInt32 = 0
-            guard AudioObjectGetPropertyDataSize(deviceID, &addr, 0, nil, &dataSize) == noErr else {
+            guard AudioObjectGetPropertyDataSize(deviceID, &address, 0, nil, &dataSize) == noErr else {
                 return nil
             }
 
-            // Allouer un buffer pour recevoir le CFString
-            var cfStr: CFString? = nil
-            let status = withUnsafeMutablePointer(to: &cfStr) { ptr -> OSStatus in
-                return AudioObjectGetPropertyData(deviceID, &addr, 0, nil, &dataSize, ptr)
+            var cfString: CFString? = nil
+            let status = withUnsafeMutablePointer(to: &cfString) { ptr in
+                AudioObjectGetPropertyData(deviceID, &address, 0, nil, &dataSize, ptr)
             }
-            guard status == noErr, let value = cfStr else { return nil }
 
+            guard status == noErr, let value = cfString else { return nil }
             return value as String
         }
-        func numStreams(_ scope: DeviceScope) -> Int {
-            var addr = AudioObjectPropertyAddress(
+
+        func channelCount(for scope: DeviceScope) -> Int {
+            var address = AudioObjectPropertyAddress(
                 mSelector: kAudioDevicePropertyStreamConfiguration,
                 mScope: (scope == .input) ? kAudioDevicePropertyScopeInput : kAudioDevicePropertyScopeOutput,
-                mElement: kAudioObjectPropertyElementMain)
-            var size: UInt32 = 0
-            guard AudioObjectGetPropertyDataSize(deviceID, &addr, 0, nil, &size) == noErr else { return 0 }
-            
-            let audioBufferList = UnsafeMutablePointer<AudioBufferList>.allocate(capacity: Int(size))
-            defer { audioBufferList.deallocate() }
-            
-            guard AudioObjectGetPropertyData(deviceID, &addr, 0, nil, &size, audioBufferList) == noErr else { return 0 }
-            
-            var channelCount = 0
-            let bufferList = UnsafeMutableAudioBufferListPointer(audioBufferList)
-            for buffer in bufferList {
-                channelCount += Int(buffer.mNumberChannels)
+                mElement: kAudioObjectPropertyElementMain
+            )
+
+            var dataSize: UInt32 = 0
+            guard AudioObjectGetPropertyDataSize(deviceID, &address, 0, nil, &dataSize) == noErr else {
+                return 0
             }
-            
-            return channelCount
+
+            let audioBufferList = AudioBufferList.allocate(maximumBuffers: Int(dataSize) / MemoryLayout<AudioBuffer>.stride)
+            defer { audioBufferList.deallocate() }
+
+            let status = audioBufferList.withUnsafeMutablePointer { ptr in
+                AudioObjectGetPropertyData(deviceID, &address, 0, nil, &dataSize, ptr)
+            }
+
+            guard status == noErr else { return 0 }
+
+            var channels = 0
+            for buffer in UnsafeMutableAudioBufferListPointer(audioBufferList) {
+                channels += Int(buffer.mNumberChannels)
+            }
+            return channels
         }
-        guard let name = stringProp(kAudioObjectPropertyName), let uid = stringProp(kAudioDevicePropertyDeviceUID) else { return nil }
-        let numOutputs = numStreams(.output)
-        let numInputs = numStreams(.input)
-        return AudioDevice(id: deviceID, name: name, uid: uid, numOutputs: numOutputs, numInputs: numInputs)
+
+        guard
+            let name = stringProperty(kAudioObjectPropertyName),
+            let uid = stringProperty(kAudioDevicePropertyDeviceUID)
+        else {
+            return nil
+        }
+
+        let outputs = channelCount(for: .output)
+        let inputs = channelCount(for: .input)
+
+        return AudioDevice(id: deviceID, name: name, uid: uid, numOutputs: outputs, numInputs: inputs)
     }
 
     func findDevice(byName name: String) -> AudioDevice? {
         allDevices().first { $0.name.contains(name) }
     }
-    
-    func deviceID(forUID uid: String) -> AudioDeviceID? {
-        // Direct approach: just search through all devices
-        // This is more reliable than the Core Audio UID lookup API
-        if let device = allDevices().first(where: { $0.uid == uid }) {
-            print("✅ Found device directly: \(device.name) (ID: \(device.id))")
-            return device.id
+
+    func streamFormat(deviceID: AudioDeviceID, scope: DeviceScope) -> StreamFormat? {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyStreamFormat,
+            mScope: scope == .input ? kAudioDevicePropertyScopeInput : kAudioDevicePropertyScopeOutput,
+            mElement: kAudioObjectPropertyElementMain
+        )
+
+        var asbd = AudioStreamBasicDescription()
+        var dataSize = UInt32(MemoryLayout<AudioStreamBasicDescription>.size)
+
+        let status = AudioObjectGetPropertyData(deviceID, &address, 0, nil, &dataSize, &asbd)
+        guard status == noErr else {
+            return nil
         }
-        
-        print("❌ Device not found for UID: \(uid)")
-        return nil
+
+        return StreamFormat(asbd: asbd)
+    }
+
+    func deviceID(forUID uid: String) -> AudioDeviceID? {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyDeviceForUID,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+
+        var deviceID = AudioDeviceID(0)
+        var uidString = uid as CFString
+
+        var translation = AudioValueTranslation(
+            mInputData: nil,
+            mInputDataSize: UInt32(MemoryLayout<CFString>.size),
+            mOutputData: &deviceID,
+            mOutputDataSize: UInt32(MemoryLayout<AudioDeviceID>.size)
+        )
+
+        var result: AudioDeviceID? = nil
+
+        withUnsafeMutablePointer(to: &uidString) { uidPointer in
+            translation.mInputData = UnsafeMutableRawPointer(uidPointer)
+            var dataSize = UInt32(MemoryLayout<AudioValueTranslation>.size)
+            let status = withUnsafeMutablePointer(to: &translation) { ptr in
+                AudioObjectGetPropertyData(AudioObjectID(kAudioObjectSystemObject), &address, 0, nil, &dataSize, ptr)
+            }
+
+            if status == noErr {
+                result = deviceID
+            }
+        }
+
+        if let deviceID = result {
+            return deviceID
+        }
+
+        return allDevices().first(where: { $0.uid == uid })?.id
     }
 }
-

--- a/Mixu/Audio/AudioRingBuffer.swift
+++ b/Mixu/Audio/AudioRingBuffer.swift
@@ -5,7 +5,7 @@
 //  Created by Johan Lescure on 15/09/2025.
 //
 
-import os.log
+import os.lock
 
 /// Lock-based Ring Buffer (Swift 6 safe).
 /// Single-producer / single-consumer. Uses OSAllocatedUnfairLock.
@@ -22,6 +22,8 @@ final class AudioRingBuffer {
         self.channels = channels
         self.buffer = Array(repeating: 0, count: capacityFrames * channels)
     }
+
+    var channelCount: Int { channels }
 
     func write(_ input: UnsafePointer<Float>, frames: Int) {
         let totalSamples = frames * channels
@@ -42,11 +44,6 @@ final class AudioRingBuffer {
             writeIndex = (writeIndex + n) % cap
         }
         availableFrames = min(capacityFrames, availableFrames + frames)
-        
-        // Debug: Log when audio data is written
-        if frames > 0 {
-            print("�� Ring buffer: wrote \(frames) frames, fill level: \(Double(availableFrames) / Double(capacityFrames))")
-        }
         
         lock.unlock()
     }
@@ -78,11 +75,6 @@ final class AudioRingBuffer {
         if framesToRead < frames {
             let deficit = (frames - framesToRead) * channels
             memset(output.advanced(by: samplesToRead), 0, deficit * MemoryLayout<Float>.size)
-        }
-
-        // Debug: Log when audio data is read
-        if framesToRead > 0 {
-            print("📖 Ring buffer: read \(framesToRead) frames, fill level: \(Double(availableFrames) / Double(capacityFrames))")
         }
 
         lock.unlock()

--- a/Mixu/Audio/AudioSource.swift
+++ b/Mixu/Audio/AudioSource.swift
@@ -1,0 +1,67 @@
+//
+//  AudioSource.swift
+//  Mixu
+//
+//  Created by Johan Lescure on 15/09/2025.
+//
+
+import CoreAudio
+import Foundation
+import os.lock
+
+final class AudioSource {
+    let uid: String
+    private let input: InputDevice
+    private let lock = OSAllocatedUnfairLock()
+    private let channelCount: Int
+
+    private var routes: [UUID: AudioRingBuffer] = [:]
+
+    init(uid: String, deviceID: AudioDeviceID, deviceFormat: StreamFormat, internalFormat: StreamFormat, useTestTone: Bool) throws {
+        self.uid = uid
+        self.channelCount = internalFormat.channelCount
+        self.input = try InputDevice(
+            deviceID: deviceID,
+            deviceFormat: deviceFormat,
+            internalFormat: internalFormat,
+            useTestTone: useTestTone
+        ) { [weak self] buffer, frames in
+            self?.dispatch(buffer: buffer, frames: frames)
+        }
+    }
+
+    func start() {
+        input.start()
+    }
+
+    func stop() {
+        input.stop()
+    }
+
+    func addRoute(id: UUID, ring: AudioRingBuffer) {
+        lock.lock()
+        precondition(ring.channelCount == channelCount, "Ring buffer channel count mismatch for source \(uid)")
+        routes[id] = ring
+        lock.unlock()
+    }
+
+    func removeRoute(id: UUID) -> Bool {
+        lock.lock()
+        routes.removeValue(forKey: id)
+        let hasRoutes = !routes.isEmpty
+        lock.unlock()
+        return hasRoutes
+    }
+
+    private func dispatch(buffer: UnsafePointer<Float>, frames: Int) {
+        lock.lock()
+        let targets = Array(routes.values)
+        lock.unlock()
+
+        guard !targets.isEmpty else { return }
+
+        for ring in targets {
+            ring.write(buffer, frames: frames)
+        }
+    }
+}

--- a/Mixu/Audio/InputDevice.swift
+++ b/Mixu/Audio/InputDevice.swift
@@ -7,346 +7,347 @@
 
 import AudioToolbox
 import AVFoundation
+import Foundation
 
-// MARK: - Input Device (Real or Test Tone)
+// MARK: - Input Device (Real device or synthetic test tone)
 final class InputDevice {
+    typealias SampleHandler = (_ buffer: UnsafePointer<Float>, _ frameCount: Int) -> Void
+
     private var unit: AudioUnit?
-    private var timer: Timer?
     private let deviceID: AudioDeviceID
-    private var format: StreamFormat
-    private let ring: AudioRingBuffer
+    private var deviceFormat: StreamFormat
+    private let internalFormat: StreamFormat
+    private var normalizedFormat: StreamFormat
+    private let handler: SampleHandler
+
+    private var converter: AVAudioConverter?
+    private var deviceAVFormat: AVAudioFormat
+    private var normalizedAVFormat: AVAudioFormat
+    private let internalAVFormat: AVAudioFormat
+
+    private var timer: Timer?
     private var sampleCount: Int = 0
     private var isRunning = false
-    private var isTestTone = false
-    private var callCount: Int = 0
-    
-    // Constants for test tone generation
-    private let sampleRate = 44100
-    private let frequency = 440.0 // A4 note
-    private let amplitude = 0.3
-    private let framesPerBuffer = 512
-    private let bufferCount = 3  // Number of buffers to keep filled
-    
-    init(deviceID: AudioDeviceID, format: StreamFormat, ring: AudioRingBuffer) throws {
+    private let useTestTone: Bool
+
+    // Test tone constants
+    private let frequency = 440.0
+    private let amplitude = 0.25
+    private let framesPerBuffer: Int
+
+    init(deviceID: AudioDeviceID, deviceFormat: StreamFormat, internalFormat: StreamFormat, useTestTone: Bool = false, handler: @escaping SampleHandler) throws {
         self.deviceID = deviceID
-        self.format = format
-        self.ring = ring
-        
-        // Determine if we should use test tone based on device ID
-        isTestTone = (deviceID == 0)
-        
-        if isTestTone {
+        self.deviceFormat = deviceFormat
+        self.internalFormat = internalFormat
+        self.handler = handler
+        self.useTestTone = useTestTone || deviceID == 0
+
+        var internalFormatCopy = internalFormat.asbd
+        guard let internalAV = AVAudioFormat(streamDescription: &internalFormatCopy) else {
+            throw NSError(domain: NSOSStatusErrorDomain, code: Int(kAudio_ParamError), userInfo: nil)
+        }
+        internalAVFormat = internalAV
+
+        normalizedFormat = StreamFormat.make(
+            sampleRate: internalFormat.sampleRate,
+            channels: UInt32(max(1, deviceFormat.channelCount))
+        )
+        var normalizedCopy = normalizedFormat.asbd
+        guard let normalizedAV = AVAudioFormat(streamDescription: &normalizedCopy) else {
+            throw NSError(domain: NSOSStatusErrorDomain, code: Int(kAudio_ParamError), userInfo: nil)
+        }
+        normalizedAVFormat = normalizedAV
+
+        var deviceFormatCopy = deviceFormat.asbd
+        guard let deviceAV = AVAudioFormat(streamDescription: &deviceFormatCopy) else {
+            throw NSError(domain: NSOSStatusErrorDomain, code: Int(kAudio_ParamError), userInfo: nil)
+        }
+        deviceAVFormat = deviceAV
+
+        framesPerBuffer = max(128, min(2048, Int(internalFormat.sampleRate / 100)))
+
+        if self.useTestTone {
             setupTestTone()
         } else {
-            try setupRealDevice()
+            try setupHardwareInput()
         }
     }
-    
-    private func setupTestTone() {
-        print("🎤 Setting up test tone generator (440 Hz sine wave)")
+
+    deinit {
+        stop()
+        if let unit { AudioComponentInstanceDispose(unit) }
     }
-    
-    private func setupRealDevice() throws {
-        print("🎤 Setting up real device input with device ID: \(deviceID)")
-        
-        var desc = AudioComponentDescription(componentType: kAudioUnitType_Output,
-                                             componentSubType: kAudioUnitSubType_HALOutput,
-                                             componentManufacturer: kAudioUnitManufacturer_Apple,
-                                             componentFlags: 0, componentFlagsMask: 0)
-        guard let comp = AudioComponentFindNext(nil, &desc) else { throw NSError(domain: "HAL", code: -1) }
-        var u: AudioUnit?
-        let status1 = AudioComponentInstanceNew(comp, &u)
-        if status1 != noErr {
-            print("❌ AudioComponentInstanceNew input failed with error \(status1)")
-            throw NSError(domain: "HAL", code: Int(status1))
-        }
-        unit = u
-        
-        // Enable input on bus 1, disable output on bus 0
-        var enableIO: UInt32 = 1
-        let status2 = AudioUnitSetProperty(u!, kAudioOutputUnitProperty_EnableIO, kAudioUnitScope_Input, 1, &enableIO, UInt32(MemoryLayout.size(ofValue: enableIO)))
-        if status2 != noErr {
-            print("❌ Enable input failed with error \(status2)")
-        }
-        
-        var disableIO: UInt32 = 0
-        let status3 = AudioUnitSetProperty(u!, kAudioOutputUnitProperty_EnableIO, kAudioUnitScope_Output, 0, &disableIO, UInt32(MemoryLayout.size(ofValue: disableIO)))
-        if status3 != noErr {
-            print("❌ Disable output failed with error \(status3)")
-        }
-        
-        // Bind to specific device
-        var dev = deviceID
-        print("🎤 Attempting to bind to device ID: \(deviceID)")
-        let bindStatus = AudioUnitSetProperty(u!, kAudioOutputUnitProperty_CurrentDevice, kAudioUnitScope_Global, 0, &dev, UInt32(MemoryLayout.size(ofValue: dev)))
-        if bindStatus != noErr {
-            print("❌ Failed to bind device: \(bindStatus)")
-            throw NSError(domain: "HAL", code: Int(bindStatus))
-        }
-        print("✅ Device bound successfully")
-        
-        // Query the device's supported format
-        var deviceFormat = AudioStreamBasicDescription()
-        var size = UInt32(MemoryLayout<AudioStreamBasicDescription>.size)
-        let status = AudioUnitGetProperty(u!, kAudioUnitProperty_StreamFormat, kAudioUnitScope_Output, 1, &deviceFormat, &size)
-        
-        if status == noErr {
-            print("📊 Device native format: \(deviceFormat.mSampleRate)Hz, \(deviceFormat.mChannelsPerFrame)ch")
-            print("📊 Format flags: \(deviceFormat.mFormatFlags)")
-            print("📊 Bits per channel: \(deviceFormat.mBitsPerChannel)")
-            print("📊 Bytes per frame: \(deviceFormat.mBytesPerFrame)")
-            
-            // Check if non-interleaved
-            let isNonInterleaved = (deviceFormat.mFormatFlags & kAudioFormatFlagIsNonInterleaved) != 0
-            print("📊 Format is \(isNonInterleaved ? "non-interleaved" : "interleaved")")
-            
-            // Create a new format that's always interleaved - safer and easier to handle
-            var newFormat = deviceFormat
-            newFormat.mFormatFlags &= ~kAudioFormatFlagIsNonInterleaved  // Clear non-interleaved flag
-            newFormat.mBytesPerFrame = UInt32(4 * Int(newFormat.mChannelsPerFrame))
-            newFormat.mBytesPerPacket = newFormat.mBytesPerFrame
-            
-            // Set the format on the output scope (where we read from)
-            let status4 = AudioUnitSetProperty(u!, kAudioUnitProperty_StreamFormat, kAudioUnitScope_Output, 1, &newFormat, UInt32(MemoryLayout<AudioStreamBasicDescription>.size))
-            if status4 != noErr {
-                print("❌ Set device format output failed with error \(status4)")
-            }
-            
-            // Update our format to match
-            self.format = StreamFormat(asbd: newFormat)
-        } else {
-            print("⚠️ Could not query device format, using default")
-            // Fall back to our default format - ensure it's interleaved
-            var asbd = format.asbd
-            asbd.mFormatFlags &= ~kAudioFormatFlagIsNonInterleaved  // Clear non-interleaved flag
-            asbd.mBytesPerFrame = UInt32(4 * Int(asbd.mChannelsPerFrame))
-            asbd.mBytesPerPacket = asbd.mBytesPerFrame
-            
-            let status5 = AudioUnitSetProperty(u!, kAudioUnitProperty_StreamFormat, kAudioUnitScope_Output, 1, &asbd, UInt32(MemoryLayout<AudioStreamBasicDescription>.size))
-            if status5 != noErr {
-                print("❌ Set input stream format output failed with error \(status5)")
-            }
-            
-            // Update our format
-            self.format = StreamFormat(asbd: asbd)
-        }
-        
-        // Set up the render callback
-        let ctx = UnsafeMutableRawPointer(Unmanaged.passUnretained(self).toOpaque())
-        var cb = AURenderCallbackStruct(
-            inputProc: { inRefCon, ioActionFlags, inTimeStamp, inBusNumber, inNumberFrames, ioData -> OSStatus in
-                let ref = Unmanaged<InputDevice>.fromOpaque(inRefCon).takeUnretainedValue()
-                return ref.onRender(inNumberFrames: inNumberFrames)
-            },
-            inputProcRefCon: ctx
-        )
-        
-        // Use the correct property for input callback
-        let status6 = AudioUnitSetProperty(u!,
-                                   kAudioOutputUnitProperty_SetInputCallback,
-                                   kAudioUnitScope_Global,
-                                   0,
-                                   &cb,
-                                   UInt32(MemoryLayout<AURenderCallbackStruct>.size))
-        if status6 != noErr {
-            print("❌ Set input callback failed with error \(status6)")
-        }
-        
-        // Initialize the Audio Unit
-        let status7 = AudioUnitInitialize(u!)
-        if status7 != noErr {
-            print("❌ Initialize input AUHAL failed with error \(status7)")
-        }
-    }
-    
+
     func start() {
-        isRunning = true
-        
-        if isTestTone {
-            print("🎤 Starting test tone generator")
-            // Fill the buffer initially with multiple chunks
-            for _ in 0..<bufferCount {
-                generateTestTone()
+        guard !isRunning else { return }
+
+        if useTestTone {
+            isRunning = true
+            primeTestTone()
+            timer = Timer.scheduledTimer(withTimeInterval: Double(framesPerBuffer) / max(1.0, internalFormat.sampleRate), repeats: true) { [weak self] _ in
+                self?.generateTestTone()
             }
-            
-            // Start a timer to keep the buffer filled
-            timer = Timer.scheduledTimer(withTimeInterval: 0.01, repeats: true) { [weak self] _ in
-                guard let self = self, self.isRunning else { return }
-                
-                // Only generate more audio if the buffer is getting low
-                if self.ring.fillLevel() < 0.5 {
-                    self.generateTestTone()
-                }
-            }
-        } else {
-            print("🎤 Starting real device input")
-            if let u = unit {
-                let status = AudioOutputUnitStart(u)
-                print("🎤 Starting input device: status = \(status)")
-                if status != noErr {
-                    print("❌ Failed to start input device: \(status)")
-                }
+        } else if let unit {
+            let status = AudioOutputUnitStart(unit)
+            if status != noErr {
+                print("InputDevice start failed: \(status)")
+                isRunning = false
+            } else {
+                isRunning = true
             }
         }
     }
-    
+
     func stop() {
+        guard isRunning else { return }
         isRunning = false
-        
-        if isTestTone {
-            print("🎤 Stopping test tone generator")
+
+        if useTestTone {
             timer?.invalidate()
             timer = nil
-        } else {
-            print("🎤 Stopping real device input")
-            if let u = unit {
-                let status = AudioOutputUnitStop(u)
-                print("🎤 Stopping input device: status = \(status)")
+        } else if let unit {
+            let status = AudioOutputUnitStop(unit)
+            if status != noErr {
+                print("InputDevice stop failed: \(status)")
             }
         }
     }
-    
-    private func generateTestTone() {
-        // Allocate buffer for stereo interleaved audio
-        let buffer = UnsafeMutablePointer<Float>.allocate(capacity: framesPerBuffer * 2)
+}
+
+// MARK: - Test tone helpers
+private extension InputDevice {
+    func setupTestTone() {
+        // Nothing to configure in advance, tone will be generated in software.
+    }
+
+    func primeTestTone() {
+        for _ in 0..<4 {
+            generateTestTone()
+        }
+    }
+
+    func generateTestTone() {
+        guard isRunning else { return }
+
+        let channels = Int(internalFormat.asbd.mChannelsPerFrame)
+        let sampleRate = max(1.0, internalFormat.sampleRate)
+        let buffer = UnsafeMutablePointer<Float>.allocate(capacity: framesPerBuffer * channels)
         defer { buffer.deallocate() }
-        
-        // Generate sine wave
-        for i in 0..<framesPerBuffer {
-            let time = Double(sampleCount + i) / Double(sampleRate)
-            let sample = Float(amplitude * sin(2.0 * .pi * frequency * time))
-            
-            // Interleaved stereo (left, right)
-            buffer[i * 2] = sample
-            buffer[i * 2 + 1] = sample
-        }
-        
-        // Update sample count
-        sampleCount += framesPerBuffer
-        
-        // Write to ring buffer
-        ring.write(buffer, frames: framesPerBuffer)
-        
-        // Periodically log the buffer fill level
-        if sampleCount % (framesPerBuffer * 20) == 0 {
-            print("🎤 Generated test tone: buffer fill level: \(ring.fillLevel())")
-        }
-    }
-    
-    private func onRender(inNumberFrames: UInt32) -> OSStatus {
-        guard let unit = unit else { return noErr }
-        
-        // Check if ring buffer is getting too full
-        let fillLevel = ring.fillLevel()
-        if fillLevel > 0.9 {
-            // Skip this frame to avoid buffer overflow
-            if callCount % 50 == 0 {
-                print("⚠️ Ring buffer nearly full (\(fillLevel)), skipping frame to prevent overflow")
+
+        for frame in 0..<framesPerBuffer {
+            let time = Double(sampleCount + frame) / sampleRate
+            let value = Float(amplitude * sin(2.0 * .pi * frequency * time))
+
+            for channel in 0..<channels {
+                buffer[frame * channels + channel] = value
             }
-            callCount += 1
+        }
+
+        sampleCount += framesPerBuffer
+        handler(buffer, framesPerBuffer)
+    }
+}
+
+// MARK: - Hardware configuration
+private extension InputDevice {
+    func setupHardwareInput() throws {
+        var description = AudioComponentDescription(
+            componentType: kAudioUnitType_Output,
+            componentSubType: kAudioUnitSubType_HALOutput,
+            componentManufacturer: kAudioUnitManufacturer_Apple,
+            componentFlags: 0,
+            componentFlagsMask: 0
+        )
+
+        guard let component = AudioComponentFindNext(nil, &description) else {
+            throw NSError(domain: NSOSStatusErrorDomain, code: Int(kAudioUnitErr_InvalidProperty), userInfo: nil)
+        }
+
+        var newUnit: AudioUnit?
+        try check(AudioComponentInstanceNew(component, &newUnit), message: "AudioComponentInstanceNew")
+        unit = newUnit
+        guard let unit else { throw NSError(domain: NSOSStatusErrorDomain, code: Int(kAudioUnitErr_Uninitialized), userInfo: nil) }
+
+        var enableIO: UInt32 = 1
+        try check(AudioUnitSetProperty(unit, kAudioOutputUnitProperty_EnableIO, kAudioUnitScope_Input, 1, &enableIO, UInt32(MemoryLayout.size(ofValue: enableIO))), message: "Enable input bus")
+
+        var disableIO: UInt32 = 0
+        try check(AudioUnitSetProperty(unit, kAudioOutputUnitProperty_EnableIO, kAudioUnitScope_Output, 0, &disableIO, UInt32(MemoryLayout.size(ofValue: disableIO))), message: "Disable output bus")
+
+        var device = deviceID
+        try check(AudioUnitSetProperty(unit, kAudioOutputUnitProperty_CurrentDevice, kAudioUnitScope_Global, 0, &device, UInt32(MemoryLayout.size(ofValue: device))), message: "Bind device")
+
+        var desiredFormat = deviceFormat.asbd
+        desiredFormat.mFormatID = kAudioFormatLinearPCM
+        desiredFormat.mFormatFlags = kLinearPCMFormatFlagIsFloat | kLinearPCMFormatFlagIsPacked
+        desiredFormat.mBitsPerChannel = 32
+        desiredFormat.mBytesPerFrame = UInt32(4 * Int(desiredFormat.mChannelsPerFrame))
+        desiredFormat.mFramesPerPacket = 1
+        desiredFormat.mBytesPerPacket = desiredFormat.mBytesPerFrame
+
+        let size = UInt32(MemoryLayout<AudioStreamBasicDescription>.size)
+        let setStatus = AudioUnitSetProperty(unit, kAudioUnitProperty_StreamFormat, kAudioUnitScope_Output, 1, &desiredFormat, size)
+
+        var appliedFormat = desiredFormat
+        if setStatus != noErr {
+            var actualFormat = AudioStreamBasicDescription()
+            var actualSize = size
+            try check(AudioUnitGetProperty(unit, kAudioUnitProperty_StreamFormat, kAudioUnitScope_Output, 1, &actualFormat, &actualSize), message: "Query device stream format")
+            appliedFormat = actualFormat
+        }
+
+        try updateDeviceFormat(using: appliedFormat)
+
+        configureConverter()
+
+        let selfPointer = UnsafeMutableRawPointer(Unmanaged.passUnretained(self).toOpaque())
+        var callback = AURenderCallbackStruct(
+            inputProc: { refCon, _, _, _, frameCount, _ -> OSStatus in
+                let input = Unmanaged<InputDevice>.fromOpaque(refCon).takeUnretainedValue()
+                return input.render(frameCount: frameCount)
+            },
+            inputProcRefCon: selfPointer
+        )
+
+        try check(AudioUnitSetProperty(unit, kAudioOutputUnitProperty_SetInputCallback, kAudioUnitScope_Global, 0, &callback, UInt32(MemoryLayout<AURenderCallbackStruct>.size)), message: "Install input callback")
+        try check(AudioUnitInitialize(unit), message: "Initialize input unit")
+    }
+
+    func render(frameCount: UInt32) -> OSStatus {
+        guard let unit else { return noErr }
+
+        let frames = Int(frameCount)
+        guard frames > 0 else { return noErr }
+
+        guard let deviceBuffer = AVAudioPCMBuffer(pcmFormat: deviceAVFormat, frameCapacity: frameCount) else {
             return noErr
         }
-        
-        // Use a much simpler approach - allocate a single buffer for the audio data
-        let channels = Int(format.asbd.mChannelsPerFrame)
-        
-        // Create a buffer to hold the audio data
-        let buffer = UnsafeMutablePointer<Float>.allocate(capacity: Int(inNumberFrames) * channels)
-        defer { buffer.deallocate() }
-        
-        // Create a simple AudioBufferList
-        var abl = AudioBufferList()
-        abl.mNumberBuffers = 1
-        abl.mBuffers.mNumberChannels = UInt32(channels)
-        abl.mBuffers.mDataByteSize = inNumberFrames * UInt32(channels) * 4
-        abl.mBuffers.mData = UnsafeMutableRawPointer(buffer)
-        
-        // Call AudioUnitRender to get the audio data
+
+        var audioBufferList = deviceBuffer.mutableAudioBufferList
         var flags: AudioUnitRenderActionFlags = []
-        var timestamp = AudioTimeStamp()
-        timestamp.mFlags = [.sampleTimeValid, .hostTimeValid]
-        
-        // Call AudioUnitRender
-        let status = AudioUnitRender(unit, &flags, &timestamp, 1, inNumberFrames, &abl)
-        
-        if status != noErr {
-            print("❌ AudioUnitRender failed: \(status)")
-            
-            // Fall back to test tone if we can't get audio from the device
-            generateTestTone()
-            
-            callCount += 1
+        var timeStamp = AudioTimeStamp()
+        timeStamp.mFlags = [.sampleTimeValid, .hostTimeValid]
+
+        let status = withUnsafeMutablePointer(to: &audioBufferList) { listPtr in
+            AudioUnitRender(unit, &flags, &timeStamp, 1, frameCount, listPtr)
+        }
+
+        guard status == noErr else {
             return status
         }
-        
-        // Check if we got any audio data
-        var maxSample: Float = 0.0
-        var rmsLevel: Float = 0.0
-        
-        for i in 0..<min(Int(inNumberFrames) * channels, 100) {
-            let sample = abs(buffer[i])
-            maxSample = max(maxSample, sample)
-            rmsLevel += sample * sample
+
+        deviceBuffer.frameLength = frameCount
+
+        let workingBuffer: AVAudioPCMBuffer
+        if let converter {
+            guard let normalizedBuffer = AVAudioPCMBuffer(pcmFormat: normalizedAVFormat, frameCapacity: frameCount) else {
+                return noErr
+            }
+
+            do {
+                try converter.convert(to: normalizedBuffer, from: deviceBuffer)
+            } catch {
+                print("InputDevice conversion failed: \(error)")
+                return noErr
+            }
+
+            workingBuffer = normalizedBuffer
+        } else {
+            workingBuffer = deviceBuffer
         }
-        
-        rmsLevel = sqrt(rmsLevel / Float(min(Int(inNumberFrames) * channels, 100)))
-        
-        // Only log occasionally to avoid spam
-        callCount += 1
-        
-        // If the signal is too weak, amplify it significantly
-        if maxSample < 0.01 {
-            // Amplify the signal to make it more audible
-            let gain: Float = 20.0 // Boost by 20x for very weak signals
-            for i in 0..<Int(inNumberFrames) * channels {
-                buffer[i] *= gain
-            }
-            
-            if callCount % 100 == 0 {
-                print("🎤 Amplifying weak signal: original max \(maxSample), amplified max \(min(maxSample * gain, 1.0)), RMS: \(rmsLevel)")
-            }
-        } else if callCount % 100 == 0 {
-            print("🎤 Real device max sample: \(maxSample), RMS: \(rmsLevel), buffer fill level: \(fillLevel)")
+
+        guard let internalBuffer = AVAudioPCMBuffer(pcmFormat: internalAVFormat, frameCapacity: frameCount) else {
+            return noErr
         }
-        
-        // Apply a noise gate to remove very low level noise
-        let noiseGate: Float = 0.001
-        for i in 0..<Int(inNumberFrames) * channels {
-            if abs(buffer[i]) < noiseGate {
-                buffer[i] = 0.0
-            }
+
+        mapChannels(from: workingBuffer, to: internalBuffer)
+
+        let producedFrames = Int(internalBuffer.frameLength)
+        guard producedFrames > 0, let data = internalBuffer.floatChannelData?.pointee else {
+            return noErr
         }
-        
-        // Write to ring buffer
-        ring.write(buffer, frames: Int(inNumberFrames))
-        
-        // If signal is extremely weak, mix in a test tone to verify routing
-        if maxSample < 0.0005 && callCount % 3 == 0 { // Only mix in occasionally to avoid constant tone
-            // Mix in a moderate test tone to verify routing
-            let mixBuffer = UnsafeMutablePointer<Float>.allocate(capacity: framesPerBuffer * 2)
-            defer { mixBuffer.deallocate() }
-            
-            // Generate sine wave at 25% amplitude
-            for i in 0..<framesPerBuffer {
-                let time = Double(sampleCount + i) / Double(sampleRate)
-                let sample = Float(amplitude * 0.25 * sin(2.0 * .pi * frequency * time))
-                
-                // Interleaved stereo (left, right)
-                mixBuffer[i * 2] = sample
-                mixBuffer[i * 2 + 1] = sample
-            }
-            
-            // Update sample count
-            sampleCount += framesPerBuffer
-            
-            // Write to ring buffer
-            ring.write(mixBuffer, frames: framesPerBuffer)
-            
-            if callCount % 300 == 0 {
-                print("�� Mixed in test tone due to extremely weak signal")
-            }
-        }
-        
+
+        handler(UnsafePointer(data), producedFrames)
         return noErr
+    }
+
+    func updateDeviceFormat(using asbd: AudioStreamBasicDescription) throws {
+        deviceFormat = StreamFormat(asbd: asbd)
+
+        var deviceFormatCopy = asbd
+        guard let newDeviceAV = AVAudioFormat(streamDescription: &deviceFormatCopy) else {
+            throw NSError(domain: NSOSStatusErrorDomain, code: Int(kAudio_ParamError), userInfo: nil)
+        }
+        deviceAVFormat = newDeviceAV
+
+        normalizedFormat = StreamFormat.make(
+            sampleRate: internalFormat.sampleRate,
+            channels: UInt32(max(1, deviceFormat.channelCount))
+        )
+        var normalizedCopy = normalizedFormat.asbd
+        guard let newNormalizedAV = AVAudioFormat(streamDescription: &normalizedCopy) else {
+            throw NSError(domain: NSOSStatusErrorDomain, code: Int(kAudio_ParamError), userInfo: nil)
+        }
+        normalizedAVFormat = newNormalizedAV
+    }
+
+    func configureConverter() {
+        let deviceASBD = deviceFormat.asbd
+        let normalizedASBD = normalizedFormat.asbd
+
+        let needsConversion = deviceASBD.mSampleRate != normalizedASBD.mSampleRate ||
+            deviceASBD.mFormatID != normalizedASBD.mFormatID ||
+            deviceASBD.mFormatFlags != normalizedASBD.mFormatFlags ||
+            deviceASBD.mBytesPerFrame != normalizedASBD.mBytesPerFrame ||
+            deviceASBD.mFramesPerPacket != normalizedASBD.mFramesPerPacket
+
+        if needsConversion {
+            converter = AVAudioConverter(from: deviceAVFormat, to: normalizedAVFormat)
+            converter?.sampleRateConverterAlgorithm = AVSampleRateConverterAlgorithm_Mastering
+            converter?.sampleRateConverterQuality = .max
+        } else {
+            converter = nil
+        }
+    }
+
+    func mapChannels(from source: AVAudioPCMBuffer, to destination: AVAudioPCMBuffer) {
+        let frames = Int(source.frameLength)
+        destination.frameLength = AVAudioFrameCount(frames)
+
+        guard frames > 0 else { return }
+
+        let destChannels = Int(destination.format.channelCount)
+        let srcChannels = Int(source.format.channelCount)
+
+        guard let destPointer = destination.floatChannelData?.pointee else { return }
+        memset(destPointer, 0, frames * destChannels * MemoryLayout<Float>.size)
+
+        guard let sourceChannelsPointer = source.floatChannelData else { return }
+
+        if source.format.isInterleaved {
+            let src = sourceChannelsPointer.pointee
+            let limit = min(srcChannels, destChannels)
+            for frame in 0..<frames {
+                let srcBase = frame * srcChannels
+                let destBase = frame * destChannels
+                for channel in 0..<limit {
+                    destPointer[destBase + channel] = src[srcBase + channel]
+                }
+            }
+        } else {
+            let limit = min(srcChannels, destChannels)
+            for channel in 0..<limit {
+                let src = sourceChannelsPointer[channel]
+                for frame in 0..<frames {
+                    destPointer[frame * destChannels + channel] = src[frame]
+                }
+            }
+        }
+    }
+
+    func check(_ status: OSStatus, message: String) throws {
+        guard status == noErr else {
+            throw NSError(domain: NSOSStatusErrorDomain, code: Int(status), userInfo: [NSLocalizedDescriptionKey: message])
+        }
     }
 }

--- a/Mixu/Audio/OutputSink.swift
+++ b/Mixu/Audio/OutputSink.swift
@@ -7,172 +7,289 @@
 
 import AudioToolbox
 import AVFoundation
-import os.log
 
-// MARK: - Per-Destination Output with Async SRC + Fill-Level PLL
+// MARK: - Output sink with sample-rate conversion and fan-out support
 final class OutputSink {
+    typealias RenderProvider = (_ bufferList: UnsafeMutableAudioBufferListPointer, _ frameCapacity: Int) -> Int
+
     private var unit: AudioUnit?
     private let deviceID: AudioDeviceID
-    private var outFormat: StreamFormat
-    private var inFormat: StreamFormat
-    private let ring: AudioRingBuffer
+    private let internalFormat: StreamFormat
+    private var deviceFormat: StreamFormat
+    private var channelMatchFormat: StreamFormat
+    private let provider: RenderProvider
 
-    // SRC using AVAudioConverter for simplicity
-    private var converter: AVAudioConverter!
-    private var correctionPPM: Double = 0 // dynamic drift correction
+    private var converter: AVAudioConverter?
+    private let internalAVFormat: AVAudioFormat
+    private var channelMatchAVFormat: AVAudioFormat
+    private var deviceAVFormat: AVAudioFormat
+    private var isRunning = false
 
-    // Target fill control (keeps ring around this level to absorb jitter)
-    private let targetFill: Double = 0.5 // 50% full
-    private let kp: Double = 50.0       // proportional gain → adjust as needed (ppm per unit error)
-
-    private var renderCount = 0
-
-    init(deviceID: AudioDeviceID, inFormat: StreamFormat, outFormat: StreamFormat, ring: AudioRingBuffer) throws {
+    init(deviceID: AudioDeviceID, deviceFormat: StreamFormat, internalFormat: StreamFormat, provider: @escaping RenderProvider) throws {
         self.deviceID = deviceID
-        self.inFormat = inFormat
-        self.outFormat = outFormat
-        self.ring = ring
-        try setup()
+        self.deviceFormat = deviceFormat
+        self.internalFormat = internalFormat
+        self.provider = provider
+
+        var internalFormatCopy = internalFormat.asbd
+        guard let internalAVFormat = AVAudioFormat(streamDescription: &internalFormatCopy) else {
+            throw NSError(domain: NSOSStatusErrorDomain, code: Int(kAudio_ParamError), userInfo: nil)
+        }
+        self.internalAVFormat = internalAVFormat
+
+        channelMatchFormat = StreamFormat.make(
+            sampleRate: internalFormat.sampleRate,
+            channels: UInt32(max(1, deviceFormat.channelCount))
+        )
+        var channelMatchCopy = channelMatchFormat.asbd
+        guard let channelMatchAV = AVAudioFormat(streamDescription: &channelMatchCopy) else {
+            throw NSError(domain: NSOSStatusErrorDomain, code: Int(kAudio_ParamError), userInfo: nil)
+        }
+        channelMatchAVFormat = channelMatchAV
+
+        var deviceFormatCopy = deviceFormat.asbd
+        guard let deviceAV = AVAudioFormat(streamDescription: &deviceFormatCopy) else {
+            throw NSError(domain: NSOSStatusErrorDomain, code: Int(kAudio_ParamError), userInfo: nil)
+        }
+        deviceAVFormat = deviceAV
+
+        try setupHardwareOutput()
+        configureConverter()
     }
 
-    private func setup() throws {
-        var desc = AudioComponentDescription(
-            componentType: kAudioUnitType_Output,
-            componentSubType: kAudioUnitSubType_DefaultOutput, // 🔑
-            componentManufacturer: kAudioUnitManufacturer_Apple,
-            componentFlags: 0, componentFlagsMask: 0
-        )
-        guard let comp = AudioComponentFindNext(nil, &desc) else {
-            throw NSError(domain: "HAL", code: -2, userInfo: [NSLocalizedDescriptionKey: "HALOutput not found"])
-        }
-        var u: AudioUnit?
-        check(AudioComponentInstanceNew(comp, &u), "AudioComponentInstanceNew output")
-        unit = u
-
-        // Enable output on bus 0
-        var enableIO: UInt32 = 1
-        check(AudioUnitSetProperty(u!, kAudioOutputUnitProperty_EnableIO, kAudioUnitScope_Output, 0, &enableIO, UInt32(MemoryLayout.size(ofValue: enableIO))), "Enable output")
-        // Disable input on bus 1
-        var disableIO: UInt32 = 0
-        check(AudioUnitSetProperty(u!, kAudioOutputUnitProperty_EnableIO, kAudioUnitScope_Input, 1, &disableIO, UInt32(MemoryLayout.size(ofValue: disableIO))), "Disable input")
-
-        // Bind to specific device
-        var dev = deviceID
-        check(AudioUnitSetProperty(u!, kAudioOutputUnitProperty_CurrentDevice, kAudioUnitScope_Global, 0, &dev, UInt32(MemoryLayout.size(ofValue: dev))), "Bind output device")
-
-        // Configure AU input format to match our output format (to the physical device)
-        var outASBD = outFormat.asbd
-        check(AudioUnitSetProperty(u!, kAudioUnitProperty_StreamFormat, kAudioUnitScope_Input, 0, &outASBD, UInt32(MemoryLayout<AudioStreamBasicDescription>.size)), "Set output stream format")
-
-        // Render callback (6 params!)
-        let ctx = UnsafeMutableRawPointer(Unmanaged.passUnretained(self).toOpaque())
-        var cb = AURenderCallbackStruct(
-            inputProc: { inRefCon, ioActionFlags, inTimeStamp, inBusNumber, inNumberFrames, ioData -> OSStatus in
-                let ref = Unmanaged<OutputSink>.fromOpaque(inRefCon).takeUnretainedValue()
-                return ref.renderOutput(inNumberFrames: inNumberFrames, ioData: ioData!)
-            },
-            inputProcRefCon: ctx
-        )
-        check(AudioUnitSetProperty(u!, kAudioUnitProperty_SetRenderCallback, kAudioUnitScope_Input, 0, &cb, UInt32(MemoryLayout<AURenderCallbackStruct>.size)), "Set output render callback")
-
-        check(AudioUnitInitialize(u!), "Initialize output AUHAL")
-
-        // Create converter (input = ring format, output = AU/physical format)
-        let inFormatAV = AVAudioFormat(streamDescription: &self.inFormat.asbd)!
-        let outFormatAV = AVAudioFormat(streamDescription: &outASBD)!
-        converter = AVAudioConverter(from: inFormatAV, to: outFormatAV)
-        converter.sampleRateConverterAlgorithm = AVSampleRateConverterAlgorithm_Mastering
-        converter.sampleRateConverterQuality = .max
-    }
-
-    // Add more detailed logging to the OutputSink
-    private func renderOutput(inNumberFrames: UInt32, ioData: UnsafeMutablePointer<AudioBufferList>) -> OSStatus {
-        // Get buffer list for easier access
-        let buffers = UnsafeMutableAudioBufferListPointer(ioData)
-        
-        // Log buffer details
-        print("🔍 OutputSink renderOutput called:")
-        print("  - Number of frames: \(inNumberFrames)")
-        print("  - Number of buffers: \(buffers.count)")
-        for i in 0..<buffers.count {
-            print("  - Buffer \(i): \(buffers[i].mNumberChannels) channels, \(buffers[i].mDataByteSize) bytes")
-        }
-        
-        // Check if ring buffer has data
-        let fillLevel = ring.fillLevel()
-        print("  - Ring buffer fill level: \(fillLevel)")
-        
-        if fillLevel == 0.0 {
-            // Output silence if no data available
-            for i in 0..<buffers.count {
-                memset(buffers[i].mData, 0, Int(buffers[i].mDataByteSize))
-            }
-            return noErr
-        }
-
-        // Pull from ring buffer
-        let framesNeeded = Int(inNumberFrames)
-        let channels = Int(inFormat.asbd.mChannelsPerFrame)
-        let tmp = UnsafeMutablePointer<Float>.allocate(capacity: framesNeeded * channels)
-        defer { tmp.deallocate() }
-        
-        let pulled = ring.read(into: tmp, frames: framesNeeded)
-        
-        print("  - Pulled \(pulled) frames from ring buffer")
-        
-        if pulled == 0 {
-            // Output silence if no data pulled
-            for i in 0..<buffers.count {
-                memset(buffers[i].mData, 0, Int(buffers[i].mDataByteSize))
-            }
-            return noErr
-        }
-
-        // Check if output is interleaved or non-interleaved
-        let isOutputInterleaved = buffers.count == 1 && buffers[0].mNumberChannels > 1
-        print("  - Output format is \(isOutputInterleaved ? "interleaved" : "non-interleaved")")
-        
-        if isOutputInterleaved {
-            // For interleaved output, copy directly
-            let bytesPerFrame = 4 * channels  // 4 bytes per sample (32-bit float) * channels
-            let bytesToCopy = min(Int(buffers[0].mDataByteSize), pulled * bytesPerFrame)
-            
-            print("  - Copying \(bytesToCopy) bytes directly to interleaved output buffer")
-            
-            if let mData = buffers[0].mData {
-                memcpy(mData, tmp, bytesToCopy)
-            }
-        } else {
-            // For non-interleaved output, de-interleave our data
-            print("  - De-interleaving data to \(buffers.count) output buffers")
-            
-            for ch in 0..<min(channels, buffers.count) {
-                if let mData = buffers[ch].mData {
-                    let outBuffer = mData.assumingMemoryBound(to: Float.self)
-                    
-                    // Copy each channel
-                    for frame in 0..<pulled {
-                        outBuffer[frame] = tmp[frame * channels + ch]
-                    }
-                }
-            }
-        }
-
-        return noErr
+    deinit {
+        stop()
+        if let unit { AudioComponentInstanceDispose(unit) }
     }
 
     func start() {
-        guard let unit = unit else { return }
+        guard let unit, !isRunning else { return }
         let status = AudioOutputUnitStart(unit)
-        print("🔊 Starting output device: status = \(status)")
         if status != noErr {
-            print("❌ Failed to start output device: \(status)")
+            print("OutputSink start failed: \(status)")
         }
+        isRunning = status == noErr
     }
 
     func stop() {
-        guard let unit = unit else { return }
+        guard let unit, isRunning else { return }
         let status = AudioOutputUnitStop(unit)
-        print("🔇 Stopping output device: status = \(status)")
+        if status != noErr {
+            print("OutputSink stop failed: \(status)")
+        }
+        if status == noErr {
+            isRunning = false
+        }
+    }
+}
+
+// MARK: - Hardware configuration
+private extension OutputSink {
+    func setupHardwareOutput() throws {
+        var description = AudioComponentDescription(
+            componentType: kAudioUnitType_Output,
+            componentSubType: kAudioUnitSubType_HALOutput,
+            componentManufacturer: kAudioUnitManufacturer_Apple,
+            componentFlags: 0,
+            componentFlagsMask: 0
+        )
+
+        guard let component = AudioComponentFindNext(nil, &description) else {
+            throw NSError(domain: NSOSStatusErrorDomain, code: Int(kAudioUnitErr_InvalidProperty), userInfo: nil)
+        }
+
+        var newUnit: AudioUnit?
+        try check(AudioComponentInstanceNew(component, &newUnit), message: "AudioComponentInstanceNew")
+        unit = newUnit
+        guard let unit else { throw NSError(domain: NSOSStatusErrorDomain, code: Int(kAudioUnitErr_Uninitialized), userInfo: nil) }
+
+        var enableOutput: UInt32 = 1
+        try check(AudioUnitSetProperty(unit, kAudioOutputUnitProperty_EnableIO, kAudioUnitScope_Output, 0, &enableOutput, UInt32(MemoryLayout.size(ofValue: enableOutput))), message: "Enable output bus")
+
+        var disableInput: UInt32 = 0
+        try check(AudioUnitSetProperty(unit, kAudioOutputUnitProperty_EnableIO, kAudioUnitScope_Input, 1, &disableInput, UInt32(MemoryLayout.size(ofValue: disableInput))), message: "Disable input bus")
+
+        var device = deviceID
+        try check(AudioUnitSetProperty(unit, kAudioOutputUnitProperty_CurrentDevice, kAudioUnitScope_Global, 0, &device, UInt32(MemoryLayout.size(ofValue: device))), message: "Bind device")
+
+        var deviceFormatASBD = AudioStreamBasicDescription()
+        var dataSize = UInt32(MemoryLayout<AudioStreamBasicDescription>.size)
+        try check(AudioUnitGetProperty(unit, kAudioUnitProperty_StreamFormat, kAudioUnitScope_Output, 0, &deviceFormatASBD, &dataSize), message: "Query device stream format")
+
+        try updateFormats(using: deviceFormatASBD)
+
+        var inputFormatCopy = deviceFormatASBD
+        try check(AudioUnitSetProperty(unit, kAudioUnitProperty_StreamFormat, kAudioUnitScope_Input, 0, &inputFormatCopy, UInt32(MemoryLayout<AudioStreamBasicDescription>.size)), message: "Set input stream format")
+
+        let selfPointer = UnsafeMutableRawPointer(Unmanaged.passUnretained(self).toOpaque())
+        var callback = AURenderCallbackStruct(
+            inputProc: { refCon, _, _, _, frameCount, ioData -> OSStatus in
+                let sink = Unmanaged<OutputSink>.fromOpaque(refCon).takeUnretainedValue()
+                guard let ioData else { return noErr }
+                return sink.render(frameCount: frameCount, ioData: ioData)
+            },
+            inputProcRefCon: selfPointer
+        )
+
+        try check(AudioUnitSetProperty(unit, kAudioUnitProperty_SetRenderCallback, kAudioUnitScope_Input, 0, &callback, UInt32(MemoryLayout<AURenderCallbackStruct>.size)), message: "Install render callback")
+        try check(AudioUnitInitialize(unit), message: "Initialize output unit")
+    }
+
+    func render(frameCount: UInt32, ioData: UnsafeMutablePointer<AudioBufferList>) -> OSStatus {
+        guard frameCount > 0 else { return noErr }
+
+        let ioBuffers = UnsafeMutableAudioBufferListPointer(ioData)
+        zero(buffers: ioBuffers)
+
+        guard let internalBuffer = AVAudioPCMBuffer(pcmFormat: internalAVFormat, frameCapacity: AVAudioFrameCount(frameCount)) else {
+            return noErr
+        }
+
+        clear(buffer: internalBuffer)
+
+        let providedFrames = provider(UnsafeMutableAudioBufferListPointer(internalBuffer.mutableAudioBufferList), Int(frameCount))
+        let validFrames = max(0, min(providedFrames, Int(frameCount)))
+        internalBuffer.frameLength = AVAudioFrameCount(validFrames)
+
+        guard validFrames > 0 else { return noErr }
+
+        guard let channelBuffer = AVAudioPCMBuffer(pcmFormat: channelMatchAVFormat, frameCapacity: AVAudioFrameCount(frameCount)) else {
+            return noErr
+        }
+
+        clear(buffer: channelBuffer)
+        mapChannels(from: internalBuffer, to: channelBuffer)
+
+        let preparedBuffer: AVAudioPCMBuffer
+        if let converter {
+            guard let deviceBuffer = AVAudioPCMBuffer(pcmFormat: deviceAVFormat, frameCapacity: AVAudioFrameCount(frameCount)) else {
+                return noErr
+            }
+
+            clear(buffer: deviceBuffer)
+
+            do {
+                try converter.convert(to: deviceBuffer, from: channelBuffer)
+            } catch {
+                print("OutputSink conversion failed: \(error)")
+                return noErr
+            }
+
+            preparedBuffer = deviceBuffer
+        } else {
+            channelBuffer.frameLength = AVAudioFrameCount(validFrames)
+            preparedBuffer = channelBuffer
+        }
+
+        copy(from: preparedBuffer, to: ioBuffers)
+        return noErr
+    }
+
+    func zero(buffers: UnsafeMutableAudioBufferListPointer) {
+        for buffer in buffers {
+            if let data = buffer.mData {
+                memset(data, 0, Int(buffer.mDataByteSize))
+            }
+        }
+    }
+
+    func clear(buffer: AVAudioPCMBuffer) {
+        let list = UnsafeMutableAudioBufferListPointer(buffer.mutableAudioBufferList)
+        for audioBuffer in list {
+            if let data = audioBuffer.mData {
+                memset(data, 0, Int(audioBuffer.mDataByteSize))
+            }
+        }
+    }
+
+    func copy(from buffer: AVAudioPCMBuffer, to buffers: UnsafeMutableAudioBufferListPointer) {
+        let sourceBuffers = UnsafeMutableAudioBufferListPointer(buffer.mutableAudioBufferList)
+        for index in 0..<min(buffers.count, sourceBuffers.count) {
+            let byteCount = Int(sourceBuffers[index].mDataByteSize)
+            if let dst = buffers[index].mData, let src = sourceBuffers[index].mData {
+                memcpy(dst, src, byteCount)
+                buffers[index].mDataByteSize = UInt32(byteCount)
+            }
+        }
+    }
+
+    func updateFormats(using asbd: AudioStreamBasicDescription) throws {
+        deviceFormat = StreamFormat(asbd: asbd)
+
+        var deviceFormatCopy = asbd
+        guard let newDeviceAV = AVAudioFormat(streamDescription: &deviceFormatCopy) else {
+            throw NSError(domain: NSOSStatusErrorDomain, code: Int(kAudio_ParamError), userInfo: nil)
+        }
+        deviceAVFormat = newDeviceAV
+
+        channelMatchFormat = StreamFormat.make(
+            sampleRate: internalFormat.sampleRate,
+            channels: UInt32(max(1, deviceFormat.channelCount))
+        )
+        var channelMatchCopy = channelMatchFormat.asbd
+        guard let newChannelMatchAV = AVAudioFormat(streamDescription: &channelMatchCopy) else {
+            throw NSError(domain: NSOSStatusErrorDomain, code: Int(kAudio_ParamError), userInfo: nil)
+        }
+        channelMatchAVFormat = newChannelMatchAV
+    }
+
+    func configureConverter() {
+        let inputASBD = channelMatchFormat.asbd
+        let deviceASBD = deviceFormat.asbd
+
+        let needsConversion = inputASBD.mSampleRate != deviceASBD.mSampleRate ||
+            inputASBD.mFormatID != deviceASBD.mFormatID ||
+            inputASBD.mFormatFlags != deviceASBD.mFormatFlags ||
+            inputASBD.mBytesPerFrame != deviceASBD.mBytesPerFrame ||
+            inputASBD.mFramesPerPacket != deviceASBD.mFramesPerPacket
+
+        if needsConversion {
+            converter = AVAudioConverter(from: channelMatchAVFormat, to: deviceAVFormat)
+            converter?.sampleRateConverterAlgorithm = AVSampleRateConverterAlgorithm_Mastering
+            converter?.sampleRateConverterQuality = .max
+        } else {
+            converter = nil
+        }
+    }
+
+    func mapChannels(from source: AVAudioPCMBuffer, to destination: AVAudioPCMBuffer) {
+        let frames = Int(source.frameLength)
+        destination.frameLength = AVAudioFrameCount(frames)
+
+        guard frames > 0 else { return }
+
+        let destChannels = Int(destination.format.channelCount)
+        let srcChannels = Int(source.format.channelCount)
+
+        guard let destPointer = destination.floatChannelData?.pointee else { return }
+        memset(destPointer, 0, frames * destChannels * MemoryLayout<Float>.size)
+
+        guard let sourceChannelsPointer = source.floatChannelData else { return }
+
+        if source.format.isInterleaved {
+            let src = sourceChannelsPointer.pointee
+            let limit = min(srcChannels, destChannels)
+            for frame in 0..<frames {
+                let srcBase = frame * srcChannels
+                let destBase = frame * destChannels
+                for channel in 0..<limit {
+                    destPointer[destBase + channel] = src[srcBase + channel]
+                }
+            }
+        } else {
+            let limit = min(srcChannels, destChannels)
+            for channel in 0..<limit {
+                let src = sourceChannelsPointer[channel]
+                for frame in 0..<frames {
+                    destPointer[frame * destChannels + channel] = src[frame]
+                }
+            }
+        }
+    }
+
+    func check(_ status: OSStatus, message: String) throws {
+        guard status == noErr else {
+            throw NSError(domain: NSOSStatusErrorDomain, code: Int(status), userInfo: [NSLocalizedDescriptionKey: message])
+        }
     }
 }

--- a/Mixu/Audio/RouterEngine.swift
+++ b/Mixu/Audio/RouterEngine.swift
@@ -7,52 +7,46 @@ struct AudioConnection {
     let id: UUID
     let fromDeviceUID: String
     let fromPortIndex: Int
-    let toDeviceUID: String  
+    let toDeviceUID: String
     let toPortIndex: Int
 }
 
-// MARK: - Enhanced Router Engine
+// MARK: - Router Engine
 class RouterEngine: ObservableObject {
     private let deviceManager = AudioDeviceManager()
-    
-    @Published var passThruName: String = "BlackHole 64ch"
+
+    @Published var passThruName: String = "BlackHole 64ch" {
+        didSet { refreshCanonicalFormat() }
+    }
     @Published var selectedOutputs: Set<String> = []
     @Published var audioConnections: [AudioConnection] = []
-    
-    private var inputs: [String: InputDevice] = [:]  // UID → input device
-    private var sinks: [String: OutputSink] = [:]    // UID → output sink
-    private var rings: [String: AudioRingBuffer] = [:] // Connection ID → ring buffer
-    
-    private var inFormat = StreamFormat.make(sampleRate: 48000, channels: 2)
-    
+
+    private var sources: [String: AudioSource] = [:]
+    private var destinations: [String: AudioDestination] = [:]
+    private var rings: [UUID: AudioRingBuffer] = [:]
+
+    private var canonicalFormat = StreamFormat.make(sampleRate: 48_000, channels: 2)
+
+    init() {
+        refreshCanonicalFormat()
+    }
+
     func availableOutputs() -> [AudioDevice] {
         deviceManager.allDevices().filter { $0.numOutputs > 0 }
     }
-    
+
     func availableInputs() -> [AudioDevice] {
         deviceManager.allDevices().filter { $0.numInputs > 0 }
     }
-    
-    func getPassThru() -> AudioDevice {
-        deviceManager.findDevice(byName: passThruName)!
+
+    func passThruDevice() -> AudioDevice? {
+        deviceManager.findDevice(byName: passThruName)
     }
-    
+
     // MARK: - Connection Management
     func createAudioConnection(id: UUID, fromDeviceUID: String, fromPort: Int, toDeviceUID: String, toPort: Int) {
-        print("Creating audio connection:")
-        print("  From UID: \(fromDeviceUID)")
-        print("  To UID: \(toDeviceUID)")
-        
-        // Debug: List all available device UIDs
-        print("Available input devices:")
-        for device in availableInputs() {
-            print("  - \(device.name): \(device.uid)")
-        }
-        print("Available output devices:")
-        for device in availableOutputs() {
-            print("  - \(device.name): \(device.uid)")
-        }
-        
+        refreshCanonicalFormat()
+
         let connection = AudioConnection(
             id: id,
             fromDeviceUID: fromDeviceUID,
@@ -60,158 +54,173 @@ class RouterEngine: ObservableObject {
             toDeviceUID: toDeviceUID,
             toPortIndex: toPort
         )
-        
+
+        let sampleRate = canonicalFormat.sampleRate > 0 ? canonicalFormat.sampleRate : 48_000
+        let capacity = Int(sampleRate / 10.0)
+        let ring = AudioRingBuffer(capacityFrames: max(1, capacity), channels: canonicalFormat.channelCount)
+
+        guard let source = ensureSource(uid: fromDeviceUID) else {
+            print("Failed to create source for UID \(fromDeviceUID)")
+            return
+        }
+
+        guard let destination = ensureDestination(uid: toDeviceUID) else {
+            print("Failed to create destination for UID \(toDeviceUID)")
+            if !source.removeRoute(id: id) {
+                releaseSource(uid: fromDeviceUID)
+            }
+            return
+        }
+
+        rings[id] = ring
+        source.addRoute(id: id, ring: ring)
+        destination.addRoute(id: id, ring: ring)
+
+        source.start()
+        destination.start()
+
         audioConnections.append(connection)
-        setupAudioRouting(for: connection)
     }
-    
+
     func removeAudioConnection(id: UUID) {
-        audioConnections.removeAll { $0.id == id }
-        teardownAudioRouting(for: id)
+        guard let index = audioConnections.firstIndex(where: { $0.id == id }) else { return }
+        let connection = audioConnections.remove(at: index)
+        teardownAudioRouting(for: connection)
     }
-    
-    // Update the setupAudioRouting method to always use real devices
-    private func setupAudioRouting(for connection: AudioConnection) {
-        // Create dedicated ring buffer for this connection
-        let ring = AudioRingBuffer(capacityFrames: 4800, channels: 2)
-        rings[connection.id.uuidString] = ring
-        
-        // Always try to use real device input first
-        if let inputDevice = availableInputs().first(where: { $0.uid == connection.fromDeviceUID }) {
-            print("🎤 Setting up real input device: \(inputDevice.name)")
-            setupInputDevice(uid: connection.fromDeviceUID, ring: ring)
-        } else {
-            // Fall back to test tone only if device not found
-            print("⚠️ Input device not found, using test tone generator")
-            setupTestToneGenerator(uid: connection.fromDeviceUID, ring: ring)
-        }
-        
-        // Setup output device
-        if let outputDevice = availableOutputs().first(where: { $0.uid == connection.toDeviceUID }) {
-            print("🔊 Setting up real output device: \(outputDevice.name)")
-            setupOutputDevice(uid: connection.toDeviceUID, ring: ring)
-        } else {
-            print("❌ Output device not found: \(connection.toDeviceUID)")
-        }
-    }
-    
-    private func setupTestToneGenerator(uid: String, ring: AudioRingBuffer) {
-        // Create a test tone generator instead of a real input device
-        print("🎵 Setting up test tone generator for \(uid)")
-        
-        do {
-            // Use dummy device ID since we're not actually using it
-            let dummyDeviceID: AudioDeviceID = 0
-            let testTone = try InputDevice(deviceID: dummyDeviceID, format: inFormat, ring: ring)
-            inputs[uid] = testTone
-            testTone.start()
-            print("🎵 Started test tone generator for \(uid)")
-        } catch {
-            print("❌ Failed to start test tone generator: \(error)")
-        }
-    }
-    
-    private func setupInputDevice(uid: String, ring: AudioRingBuffer) {
-        guard inputs[uid] == nil else { return }
-        
-        guard let device = deviceManager.allDevices().first(where: { $0.uid == uid }),
-              let deviceID = deviceManager.deviceID(forUID: uid) else {
-            print("❌ Input device not found: \(uid)")
-            return
-        }
-        
-        // Only set up input devices that actually have inputs
-        guard device.numInputs > 0 else {
-            print("❌ Device has no inputs: \(device.name)")
-            return
-        }
-        
-        do {
-            let input = try InputDevice(deviceID: deviceID, format: inFormat, ring: ring)
-            inputs[uid] = input
-            input.start()
-            print("✅ Started input device: \(device.name)")
-        } catch {
-            print("❌ Failed to start input \(device.name): \(error)")
-        }
-    }
-    
-    private func setupOutputDevice(uid: String, ring: AudioRingBuffer) {
-        guard sinks[uid] == nil else { return }
-        
-        guard let device = deviceManager.allDevices().first(where: { $0.uid == uid }),
-              let deviceID = deviceManager.deviceID(forUID: uid) else {
-            print("❌ Output device not found: \(uid)")
-            return
-        }
-        
-        // Only set up output devices that actually have outputs
-        guard device.numOutputs > 0 else {
-            print("❌ Device has no outputs: \(device.name)")
-            return
-        }
-        
-        do {
-            let outFormat = StreamFormat.make(sampleRate: 48000, channels: 2)
-            let sink = try OutputSink(deviceID: deviceID, inFormat: inFormat, outFormat: outFormat, ring: ring)
-            sinks[uid] = sink
-            sink.start()
-            print("✅ Started output device: \(device.name)")
-        } catch {
-            print("❌ Failed to start output \(device.name): \(error)")
-        }
-    }
-    
-    private func teardownAudioRouting(for connectionId: UUID) {
-        let connectionIdString = connectionId.uuidString
-        rings.removeValue(forKey: connectionIdString)
-        
-        // Clean up unused inputs and outputs
-        cleanupUnusedDevices()
-    }
-    
-    private func cleanupUnusedDevices() {
-        let usedInputUIDs = Set(audioConnections.map { $0.fromDeviceUID })
-        let usedOutputUIDs = Set(audioConnections.map { $0.toDeviceUID })
-        
-        // Remove unused inputs
-        for (uid, input) in inputs {
-            if !usedInputUIDs.contains(uid) {
-                input.stop()
-                inputs.removeValue(forKey: uid)
-            }
-        }
-        
-        // Remove unused outputs
-        for (uid, sink) in sinks {
-            if !usedOutputUIDs.contains(uid) {
-                sink.stop()
-                sinks.removeValue(forKey: uid)
-            }
-        }
-    }
-    
-    // MARK: - Legacy methods (keep for compatibility)
+
     func start() {
-        // Legacy start - now connections are managed individually
+        // Connections are started on demand.
     }
-    
+
     func stop() {
-        // Stop all audio devices
-        inputs.values.forEach { $0.stop() }
-        sinks.values.forEach { $0.stop() }
-        inputs.removeAll()
-        sinks.removeAll()
-        rings.removeAll()
         audioConnections.removeAll()
+        rings.removeAll()
+
+        for source in sources.values {
+            source.stop()
+        }
+        sources.removeAll()
+
+        for destination in destinations.values {
+            destination.stop()
+        }
+        destinations.removeAll()
     }
-    
+
     func toggleOutput(_ device: AudioDevice, enabled: Bool) {
-        // Legacy method - kept for compatibility
         if enabled {
             selectedOutputs.insert(device.uid)
         } else {
             selectedOutputs.remove(device.uid)
         }
+    }
+}
+
+// MARK: - Helpers
+private extension RouterEngine {
+    func refreshCanonicalFormat() {
+        guard let passDevice = passThruDevice() else {
+            canonicalFormat = StreamFormat.make(sampleRate: 48_000, channels: 2)
+            return
+        }
+
+        let outputFormat = deviceManager.streamFormat(deviceID: passDevice.id, scope: .output)
+        let inputFormat = deviceManager.streamFormat(deviceID: passDevice.id, scope: .input)
+
+        let reference = outputFormat ?? inputFormat
+        let channels = UInt32(max(1, reference?.channelCount ?? 2))
+        let rate = reference?.sampleRate ?? 48_000
+
+        canonicalFormat = StreamFormat.make(sampleRate: rate > 0 ? rate : 48_000, channels: channels)
+    }
+
+    func ensureSource(uid: String) -> AudioSource? {
+        if let existing = sources[uid] { return existing }
+
+        guard let deviceID = deviceManager.deviceID(forUID: uid) else {
+            // Fall back to a software generated tone for missing devices.
+            do {
+                let source = try AudioSource(
+                    uid: uid,
+                    deviceID: 0,
+                    deviceFormat: canonicalFormat,
+                    internalFormat: canonicalFormat,
+                    useTestTone: true
+                )
+                sources[uid] = source
+                return source
+            } catch {
+                print("Unable to create test tone source: \(error)")
+                return nil
+            }
+        }
+
+        do {
+            let deviceFormat = deviceManager.streamFormat(deviceID: deviceID, scope: .input) ?? canonicalFormat
+            let source = try AudioSource(
+                uid: uid,
+                deviceID: deviceID,
+                deviceFormat: deviceFormat,
+                internalFormat: canonicalFormat,
+                useTestTone: false
+            )
+            sources[uid] = source
+            return source
+        } catch {
+            print("Source creation failed for \(uid): \(error)")
+            return nil
+        }
+    }
+
+    func ensureDestination(uid: String) -> AudioDestination? {
+        if let existing = destinations[uid] { return existing }
+
+        guard let deviceID = deviceManager.deviceID(forUID: uid) else {
+            print("Destination device not found for UID \(uid)")
+            return nil
+        }
+
+        do {
+            let deviceFormat = deviceManager.streamFormat(deviceID: deviceID, scope: .output) ?? canonicalFormat
+            let destination = try AudioDestination(
+                uid: uid,
+                deviceID: deviceID,
+                deviceFormat: deviceFormat,
+                internalFormat: canonicalFormat
+            )
+            destinations[uid] = destination
+            return destination
+        } catch {
+            print("Destination creation failed for \(uid): \(error)")
+            return nil
+        }
+    }
+
+    func teardownAudioRouting(for connection: AudioConnection) {
+        rings.removeValue(forKey: connection.id)
+
+        if let source = sources[connection.fromDeviceUID] {
+            let stillInUse = source.removeRoute(id: connection.id)
+            if !stillInUse {
+                releaseSource(uid: connection.fromDeviceUID)
+            }
+        }
+
+        if let destination = destinations[connection.toDeviceUID] {
+            let stillInUse = destination.removeRoute(id: connection.id)
+            if !stillInUse {
+                releaseDestination(uid: connection.toDeviceUID)
+            }
+        }
+    }
+
+    func releaseSource(uid: String) {
+        guard let source = sources.removeValue(forKey: uid) else { return }
+        source.stop()
+    }
+
+    func releaseDestination(uid: String) {
+        guard let destination = destinations.removeValue(forKey: uid) else { return }
+        destination.stop()
     }
 }

--- a/Mixu/Audio/StreamFormat.swift
+++ b/Mixu/Audio/StreamFormat.swift
@@ -11,6 +11,9 @@ import AVFoundation
 struct StreamFormat {
     var asbd: AudioStreamBasicDescription
 
+    var channelCount: Int { Int(asbd.mChannelsPerFrame) }
+    var sampleRate: Double { asbd.mSampleRate }
+
     static func make(sampleRate: Double, channels: UInt32) -> StreamFormat {
         var f = AudioStreamBasicDescription()
         f.mSampleRate = sampleRate

--- a/MixuTests/MixuTests.swift
+++ b/MixuTests/MixuTests.swift
@@ -10,8 +10,61 @@ import Testing
 
 struct MixuTests {
 
-    @Test func example() async throws {
-        // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+    @Test("Ring buffer preserves audio samples across write/read cycles")
+    func ringBufferRoundTrip() throws {
+        let channels = 2
+        let capacity = 256
+        let ring = AudioRingBuffer(capacityFrames: capacity, channels: channels)
+
+        var samples: [Float] = []
+        for frame in 0..<capacity {
+            let left = Float(frame) / Float(capacity)
+            let right = -left
+            samples.append(contentsOf: [left, right])
+        }
+
+        samples.withUnsafeBufferPointer { pointer in
+            ring.write(pointer.baseAddress!, frames: capacity)
+        }
+
+        let output = UnsafeMutablePointer<Float>.allocate(capacity: capacity * channels)
+        defer { output.deallocate() }
+
+        let framesRead = ring.read(into: output, frames: capacity)
+        #expect(framesRead == capacity)
+
+        for index in 0..<(capacity * channels) {
+            #expect(output[index] == samples[index])
+        }
+        #expect(ring.fillLevel() == 0)
     }
 
+    @Test("Ring buffer clears unread frames on underflow")
+    func ringBufferUnderflow() throws {
+        let channels = 2
+        let capacity = 64
+        let ring = AudioRingBuffer(capacityFrames: capacity, channels: channels)
+
+        let framesToWrite = capacity / 2
+        var samples = Array(repeating: Float(0.5), count: framesToWrite * channels)
+        samples.withUnsafeMutableBufferPointer { pointer in
+            ring.write(pointer.baseAddress!, frames: framesToWrite)
+        }
+
+        let output = UnsafeMutablePointer<Float>.allocate(capacity: capacity * channels)
+        defer { output.deallocate() }
+
+        let framesRead = ring.read(into: output, frames: capacity)
+        #expect(framesRead == framesToWrite)
+
+        for index in 0..<(framesToWrite * channels) {
+            #expect(output[index] == 0.5)
+        }
+
+        for index in (framesToWrite * channels)..<(capacity * channels) {
+            #expect(output[index] == 0)
+        }
+
+        #expect(ring.fillLevel() == 0)
+    }
 }


### PR DESCRIPTION
## Summary
- derive the router's canonical stream format from the selected pass-thru device and validate route buffer channel counts
- rework input capture to normalize hardware audio into the canonical layout with configurable sample-rate conversion and channel mapping
- update output sinks to match hardware formats, perform necessary conversions, and safely mix canonical audio into each device

## Testing
- swift test *(fails: Package.swift is not present in this project)*

------
https://chatgpt.com/codex/tasks/task_e_68cc9bd15478832390c576a925a94362